### PR TITLE
Fix entity naming, remove Dutch entity names, drop Atlassian branding…

### DIFF
--- a/custom_components/statuspage_monitor/__init__.py
+++ b/custom_components/statuspage_monitor/__init__.py
@@ -11,7 +11,7 @@ through the UI (Settings → Devices & Services → Add Integration).
 
 Supported platforms
 -------------------
-  • Atlassian Statuspage (statuspage.io) – full support
+  • Statuspage.io (statuspage.io) – full support
   • Status.io – planned
   • UptimeRobot Status Pages – planned
 
@@ -24,6 +24,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .const import CONF_PROVIDER, DOMAIN
 from .coordinator import StatusPageMonitorCoordinator
@@ -34,6 +35,26 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 
+async def _async_migrate_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Rename entity IDs that are missing the statuspage_ prefix.
+
+    Older versions of this integration did not set suggested_object_id, so HA
+    generated entity IDs straight from the device+entity name (e.g.
+    sensor.claude_overall_status).  This migration renames them to include the
+    statuspage_ prefix (sensor.statuspage_claude_overall_status) to match what
+    new installs receive.
+    """
+    ent_reg = er.async_get(hass)
+    for entity_entry in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        domain, object_id = entity_entry.entity_id.split(".", 1)
+        if object_id.startswith("statuspage_"):
+            continue
+        new_entity_id = f"{domain}.statuspage_{object_id}"
+        if ent_reg.async_get(new_entity_id) is None:
+            ent_reg.async_update_entity(entity_entry.entity_id, new_entity_id=new_entity_id)
+            _LOGGER.info("Migrated entity ID %s → %s", entity_entry.entity_id, new_entity_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up StatusPage Monitor from a config entry."""
     provider_class = get_provider(entry.data.get(CONF_PROVIDER))
@@ -42,6 +63,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Perform the first refresh; raises ConfigEntryNotReady on failure which
     # causes HA to retry setup automatically.
     await coordinator.async_config_entry_first_refresh()
+
+    # Rename legacy entity IDs (missing the statuspage_ prefix) before
+    # the platform sets up its entities.
+    await _async_migrate_entity_ids(hass, entry)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 

--- a/custom_components/statuspage_monitor/strings.json
+++ b/custom_components/statuspage_monitor/strings.json
@@ -17,7 +17,7 @@
     "error": {
       "cannot_connect": "Unable to connect to the status page. Check your network connection and the URL.",
       "invalid_url": "Invalid URL. Make sure it starts with https:// or http://.",
-      "not_a_statuspage": "No supported status page API found at this URL. Make sure the URL points to a compatible status page (e.g. Atlassian Statuspage).",
+      "not_a_statuspage": "No supported status page API found at this URL. Make sure the URL points to a compatible status page provider (e.g. statuspage.io, status.io, UptimeRobot).",
       "timeout": "Connection timed out. The server may be temporarily unavailable.",
       "unknown": "An unexpected error occurred. See the Home Assistant logs for details."
     },

--- a/custom_components/statuspage_monitor/translations/en.json
+++ b/custom_components/statuspage_monitor/translations/en.json
@@ -17,7 +17,7 @@
     "error": {
       "cannot_connect": "Unable to connect to the status page. Check your network connection and the URL.",
       "invalid_url": "Invalid URL. Make sure it starts with https:// or http://.",
-      "not_a_statuspage": "No supported status page API found at this URL. Make sure the URL points to a compatible status page (e.g. Atlassian Statuspage).",
+      "not_a_statuspage": "No supported status page API found at this URL. Make sure the URL points to a compatible status page provider (e.g. statuspage.io, status.io, UptimeRobot).",
       "timeout": "Connection timed out. The server may be temporarily unavailable.",
       "unknown": "An unexpected error occurred. See the Home Assistant logs for details."
     },

--- a/custom_components/statuspage_monitor/translations/nl.json
+++ b/custom_components/statuspage_monitor/translations/nl.json
@@ -17,7 +17,7 @@
     "error": {
       "cannot_connect": "Kan geen verbinding maken met de statuspagina. Controleer uw netwerkverbinding en de URL.",
       "invalid_url": "Ongeldige URL. Zorg ervoor dat de URL begint met https:// of http://.",
-      "not_a_statuspage": "Geen ondersteunde statuspagina-API gevonden op deze URL. Controleer of de URL verwijst naar een compatibele statuspagina (bijv. Atlassian Statuspage).",
+      "not_a_statuspage": "Geen ondersteunde statuspagina-API gevonden op deze URL. Controleer of de URL verwijst naar een compatibele statuspagina-provider.",
       "timeout": "Verbinding verlopen. De server is mogelijk tijdelijk niet beschikbaar.",
       "unknown": "Er is een onverwachte fout opgetreden. Zie de Home Assistant-logboeken voor details."
     },
@@ -41,19 +41,12 @@
   "entity": {
     "sensor": {
       "overall_status": {
-        "name": "Algemene status",
         "state": {
           "none": "Operationeel",
           "minor": "Kleine problemen",
           "major": "Grote problemen",
           "critical": "Kritiek"
         }
-      },
-      "active_incidents": {
-        "name": "Actieve incidenten"
-      },
-      "scheduled_maintenances": {
-        "name": "Geplande onderhoudswerkzaamheden"
       },
       "component_status": {
         "state": {

--- a/lovelace_example.yaml
+++ b/lovelace_example.yaml
@@ -1,4 +1,4 @@
-# Atlassian Statuspage – Lovelace example with Mushroom Cards
+# Status Page Monitor – Lovelace example with Mushroom Cards
 #
 # Requirements:
 #   - Mushroom Cards: https://github.com/piitaya/lovelace-mushroom


### PR DESCRIPTION
… from generic files

- nl.json: remove name fields from entity.sensor section so entity names always display in English regardless of HA language; state translations (Operationeel, Kleine problemen, etc.) are preserved
- strings.json / en.json: replace "Atlassian Statuspage" with a generic list of supported providers in the not_a_statuspage error message
- lovelace_example.yaml: replace "Atlassian Statuspage" header with "Status Page Monitor"
- __init__.py: replace "Atlassian Statuspage" in docstring with "Statuspage.io"; add _async_migrate_entity_ids() that renames legacy entity IDs missing the statuspage_ prefix (e.g. sensor.claude_overall_status → sensor.statuspage_claude_overall_status) on integration load

https://claude.ai/code/session_01K7CJViPAXXK5sicCYoP68X