### PR TITLE
Add active incident body sensor; remove automation README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Attributes: `description`, `page_name`, `page_url`, `page_updated_at`
 Attributes: list of incidents with `name`, `status`, `impact`, `shortlink`,
 `started_at`, `updated_at`
 
+### Active incident body
+
+| Entity | Type | Value |
+|--------|------|-------|
+| `sensor.statuspage_<name>_active_incident_body` | Text | Latest update text of the first active incident |
+
+The state contains the body text of the most recent update of the first active
+incident — ready to use directly in a dashboard Markdown card or as the
+`message` field in a notification automation. When there are no active
+incidents the sensor state is `unknown`.
+
+Attributes: `incident_name`, `incident_status`, `incident_impact`, `incident_id`
+
 ### Scheduled maintenances
 
 | Entity | Type | Value |
@@ -244,24 +257,6 @@ entities:
 type: custom:mushroom-entity-card
 entity: sensor.statuspage_claude_overall_status
 icon_color: "{{ state_attr(config.entity, 'icon_color') }}"
-```
-
-### Notification on outage (automation)
-
-```yaml
-alias: Notify on Claude outage
-trigger:
-  - platform: state
-    entity_id: sensor.statuspage_claude_overall_status
-    from: "none"
-condition: []
-action:
-  - service: notify.mobile_app_my_phone
-    data:
-      title: "Claude status change"
-      message: >
-        Status changed to {{ states('sensor.statuspage_claude_overall_status') }}.
-        {{ state_attr('sensor.statuspage_claude_overall_status', 'description') }}
 ```
 
 ---

--- a/custom_components/statuspage_monitor/providers/base.py
+++ b/custom_components/statuspage_monitor/providers/base.py
@@ -59,6 +59,7 @@ class Incident:
     shortlink: str | None = None
     started_at: str | None = None
     updated_at: str | None = None
+    body: str | None = None
 
 
 @dataclass

--- a/custom_components/statuspage_monitor/providers/statuspage_io.py
+++ b/custom_components/statuspage_monitor/providers/statuspage_io.py
@@ -127,6 +127,10 @@ class StatuspageIoProvider:
                     shortlink=inc.get("shortlink"),
                     started_at=inc.get("started_at"),
                     updated_at=inc.get("updated_at"),
+                    body=next(
+                        (u["body"] for u in inc.get("incident_updates", []) if u.get("body")),
+                        None,
+                    ),
                 )
                 for inc in raw.get("incidents", [])
                 if inc.get("status") != "resolved"

--- a/custom_components/statuspage_monitor/sensor.py
+++ b/custom_components/statuspage_monitor/sensor.py
@@ -92,6 +92,13 @@ MAINTENANCE_DESCRIPTION = SensorEntityDescription(
     icon="mdi:calendar-clock",
 )
 
+INCIDENT_BODY_DESCRIPTION = SensorEntityDescription(
+    key="active_incident_body",
+    translation_key="active_incident_body",
+    has_entity_name=True,
+    icon="mdi:text-box-outline",
+)
+
 
 # ---------------------------------------------------------------------------
 # Platform setup
@@ -124,6 +131,7 @@ async def async_setup_entry(
                 [
                     OverallStatusSensor(coordinator, entry),
                     ActiveIncidentsSensor(coordinator, entry),
+                    ActiveIncidentBodySensor(coordinator, entry),
                     ScheduledMaintenanceSensor(coordinator, entry),
                 ]
             )
@@ -286,6 +294,60 @@ class ActiveIncidentsSensor(_StatusPageEntity):
                 }
                 for inc in self._active_incidents
             ]
+        }
+
+
+# ---------------------------------------------------------------------------
+# Active incident body sensor
+# ---------------------------------------------------------------------------
+
+
+class ActiveIncidentBodySensor(_StatusPageEntity):
+    """Sensor reporting the latest update text of the first active incident.
+
+    The state is the body text of the most recent incident update, ready to
+    use directly in a Markdown card or as a notification message.  When there
+    are no active incidents the state is None (shown as 'unknown' in HA).
+    """
+
+    entity_description = INCIDENT_BODY_DESCRIPTION
+
+    def __init__(
+        self,
+        coordinator: StatusPageMonitorCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_active_incident_body"
+        self._attr_suggested_object_id = (
+            f"statuspage_{_page_slug(coordinator, entry)}_active_incident_body"
+        )
+
+    @property
+    def _first_incident(self):
+        data: StatusPageData | None = self.coordinator.data
+        incidents = data.incidents if data else []
+        return incidents[0] if incidents else None
+
+    @property
+    def native_value(self) -> str | None:
+        inc = self._first_incident
+        return inc.body if inc else None
+
+    @property
+    def icon(self) -> str:
+        return "mdi:text-box-outline" if self._first_incident else "mdi:text-box-check-outline"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        inc = self._first_incident
+        if not inc:
+            return {}
+        return {
+            "incident_id": inc.id,
+            "incident_name": inc.name,
+            "incident_status": inc.status,
+            "incident_impact": inc.impact,
         }
 
 

--- a/custom_components/statuspage_monitor/translations/en.json
+++ b/custom_components/statuspage_monitor/translations/en.json
@@ -52,6 +52,9 @@
       "active_incidents": {
         "name": "Active Incidents"
       },
+      "active_incident_body": {
+        "name": "Active Incident Body"
+      },
       "scheduled_maintenances": {
         "name": "Scheduled Maintenances"
       },

--- a/custom_components/statuspage_monitor/translations/nl.json
+++ b/custom_components/statuspage_monitor/translations/nl.json
@@ -48,6 +48,9 @@
           "critical": "Kritiek"
         }
       },
+      "active_incident_body": {
+        "name": "Actief incident – tekst"
+      },
       "component_status": {
         "state": {
           "operational": "Operationeel",


### PR DESCRIPTION
- New sensor `active_incident_body`: state is the latest update text of the first active incident, ready to use in a Markdown card or notification message without any template wrangling. State is `unknown` when there are no active incidents; attributes expose incident_name/status/impact/id.
- Extend `Incident` dataclass with optional `body` field.
- Statuspage.io provider reads `incident_updates[0].body` from the API.
- Translations added for the new sensor (en + nl).
- Remove "Notification on outage (automation)" section from README (to be revisited once the body sensor is in place).

https://claude.ai/code/session_01K7CJViPAXXK5sicCYoP68X