### PR TITLE
Add provider sensor, icon attrs, entity-ID fix, Instatus/Cachet stubs

### DIFF
--- a/custom_components/statuspage_monitor/config_flow.py
+++ b/custom_components/statuspage_monitor/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     API_TIMEOUT,
+    CONF_PAGE_NAME,
     CONF_PROVIDER,
     CONF_SCAN_INTERVAL,
     CONF_URL,
@@ -87,6 +88,7 @@ class StatusPageMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
                         data={
                             CONF_URL: url,
                             CONF_PROVIDER: provider.ID,
+                            CONF_PAGE_NAME: page_name,
                             CONF_SCAN_INTERVAL: user_input.get(
                                 CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                             ),

--- a/custom_components/statuspage_monitor/const.py
+++ b/custom_components/statuspage_monitor/const.py
@@ -7,6 +7,7 @@ PLATFORMS = ["sensor"]
 CONF_URL = "url"
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_PROVIDER = "provider"
+CONF_PAGE_NAME = "page_name"
 
 # Defaults and limits
 DEFAULT_SCAN_INTERVAL = 60  # seconds
@@ -19,6 +20,8 @@ API_TIMEOUT = 15  # seconds
 PROVIDER_STATUSPAGE_IO = "statuspage_io"
 PROVIDER_STATUS_IO = "status_io"
 PROVIDER_UPTIMEROBOT = "uptimerobot"
+PROVIDER_INSTATUS = "instatus"
+PROVIDER_CACHET = "cachet"
 
 # Overall status indicator values (normalised – shared across all providers)
 INDICATOR_NONE = "none"

--- a/custom_components/statuspage_monitor/providers/cachet.py
+++ b/custom_components/statuspage_monitor/providers/cachet.py
@@ -1,0 +1,184 @@
+"""Provider stub for Cachet (https://cachethq.io).
+
+Cachet is an open-source, self-hosted status page system.  Each installation
+runs on the operator's own infrastructure and exposes a REST API under
+``/api/v1/`` (v2) or ``/api/`` (v3).
+
+Detection strategy
+------------------
+GET {url}/api/v1/ping
+
+- Returns ``{"data": "Pong!"}`` on Cachet v2 installations.
+- If that fails, try ``GET {url}/api/ping`` for Cachet v3.
+- No authentication is required for public read endpoints.
+
+API endpoints (no authentication required)
+-------------------------------------------
+Cachet v2:
+
+- Ping:        GET {url}/api/v1/ping
+- Components:  GET {url}/api/v1/components?per_page=100
+- Incidents:   GET {url}/api/v1/incidents?per_page=50
+- Schedules:   GET {url}/api/v1/schedules?per_page=50   (v2.4+)
+
+Cachet v3 uses the same paths without ``/v1``:
+
+- Ping:        GET {url}/api/ping
+- Components:  GET {url}/api/components?per_page=100
+- Incidents:   GET {url}/api/incidents?per_page=50
+
+Response format — Cachet v2 (flat)
+------------------------------------
+::
+
+    {
+      "data": [
+        {
+          "id": 1,
+          "name": "API",
+          "description": "REST endpoints",
+          "status": 1,             # integer, see mapping below
+          "group_id": 0,
+          "updated_at": "2024-01-15T10:00:00+00:00"
+        }
+      ],
+      "meta": {
+        "pagination": { "total": 5, "current_page": 1, "per_page": 15 }
+      }
+    }
+
+Response format — Cachet v3 (JSON:API)
+----------------------------------------
+::
+
+    {
+      "data": [
+        {
+          "id": "1",
+          "type": "components",
+          "attributes": {
+            "name": "API",
+            "description": "REST endpoints",
+            "status": { "value": 1, "human": "Operational" },
+            "group": { "id": 1, "name": "Core" },
+            "updated_at": "2024-01-15T10:00:00+00:00"
+          }
+        }
+      ]
+    }
+
+Status mapping — components
+-----------------------------
+Component ``status`` field is an integer (may also be a string — always cast).
+
+    ===== =========================== =========================
+    Code  Cachet meaning              Normalised
+    ===== =========================== =========================
+    0     Unknown                     operational (fallback)
+    1     Operational                 operational
+    2     Performance Issues          degraded_performance
+    3     Partial Outage              partial_outage
+    4     Major Outage                major_outage
+    ===== =========================== =========================
+
+Status mapping — incidents
+---------------------------
+    ===== ===================== ========
+    Code  Cachet meaning        Active?
+    ===== ===================== ========
+    0     Scheduled             no
+    1     Investigating         yes
+    2     Identified            yes
+    3     Watching              yes
+    4     Fixed                 no
+    ===== ===================== ========
+
+Status mapping — schedules
+---------------------------
+    ===== ==================== ========
+    Code  Cachet meaning       Active?
+    ===== ==================== ========
+    0     Upcoming             yes
+    1     In Progress          yes
+    2     Complete             no
+    ===== ==================== ========
+
+Overall status
+--------------
+Cachet has no top-level "overall status" field.  Derive it from the worst
+component status:
+
+    component 4 (major_outage)        → indicator "critical"
+    component 3 (partial_outage)      → indicator "major"
+    component 2 (degraded_performance)→ indicator "minor"
+    all components operational/unknown→ indicator "none"
+
+Field differences vs Atlassian Statuspage
+------------------------------------------
+- No explicit overall status field (derived from components)
+- ``status`` may be int or str — always ``int(status)``
+- Incident body: available as ``message`` field (first/only body — no update history)
+- Scheduled maintenance: ``scheduled_for`` / ``scheduled_until`` fields available
+- Page updated_at: not available
+
+TODO: implement this provider
+------------------------------
+1. Implement ``detect``:
+   - Try GET {url}/api/v1/ping; on 200 + ``data == "Pong!"`` → v2 detected
+   - Try GET {url}/api/ping; on 200 + ``data == "Pong!"`` → v3 detected
+   - Store detected API prefix (``/api/v1`` or ``/api``) for use in ``fetch``
+
+2. Implement ``fetch``:
+   - Use ``asyncio.gather`` to call all endpoints in parallel:
+       a. GET {api_prefix}/components?per_page=100
+       b. GET {api_prefix}/incidents?per_page=50
+       c. GET {api_prefix}/schedules?per_page=50  (wrap in try/except; not all versions support this)
+   - Implement ``_extract_attrs(item)`` helper that normalises v2 flat items
+     and v3 JSON:API items to a plain dict (check for ``"attributes"`` key)
+   - Always cast ``status`` to int: ``int(attrs.get("status", 0))``
+   - Derive overall indicator from worst component status
+   - Filter incidents: keep only those with status in {1, 2, 3}
+   - Filter schedules: keep only those with status in {0, 1}
+
+3. Handle pagination:
+   - Check ``meta.pagination.total`` against ``meta.pagination.per_page``
+   - For simplicity, a high ``per_page`` (100 components, 50 incidents) covers
+     most self-hosted installations; full pagination is optional
+
+4. Register provider:
+   - Add ``CachetProvider`` to ``PROVIDERS`` in ``providers/__init__.py``
+   - Add ``PROVIDER_CACHET`` import in ``providers/__init__.py``
+"""
+from __future__ import annotations
+
+from typing import ClassVar
+
+import aiohttp
+
+from .base import StatusPageData
+
+
+class CachetProvider:
+    """Provider for the Cachet open-source status page platform (not yet implemented)."""
+
+    ID: ClassVar[str] = "cachet"
+    NAME: ClassVar[str] = "Cachet"
+    SHORT_NAME: ClassVar[str] = "Cachet"
+
+    @classmethod
+    async def detect(
+        cls,
+        session: aiohttp.ClientSession,
+        url: str,
+        timeout: int,
+    ) -> bool:
+        raise NotImplementedError("Cachet provider is not yet implemented")
+
+    @classmethod
+    async def fetch(
+        cls,
+        session: aiohttp.ClientSession,
+        url: str,
+        timeout: int,
+    ) -> StatusPageData:
+        raise NotImplementedError("Cachet provider is not yet implemented")

--- a/custom_components/statuspage_monitor/providers/instatus.py
+++ b/custom_components/statuspage_monitor/providers/instatus.py
@@ -1,0 +1,170 @@
+"""Provider stub for Instatus (https://instatus.com).
+
+Instatus is a hosted status-page platform used by many SaaS services.
+Pages are hosted on custom domains or on ``*.instatus.com`` subdomains.
+
+Detection strategy
+------------------
+GET {url}/summary.json
+
+- Returns HTTP 200 for valid Instatus pages.
+- The JSON body contains a ``"page"`` object with a ``"status"`` field
+  whose value is one of ``"UP"``, ``"HASISSUES"``, or ``"UNDERMAINTENANCE"``.
+- Instatus pages do NOT have a root-level ``"components"`` key — this
+  distinguishes them from Atlassian Statuspage (/api/v2/summary.json which
+  DOES have ``"components"`` at root level).
+- Try Atlassian Statuspage detection first; Instatus uses the same path
+  ``/summary.json`` without the ``/api/v2`` prefix.
+
+API endpoints (no authentication required)
+-------------------------------------------
+- Summary:    GET {url}/summary.json
+- Components: GET {url}/v2/components.json
+
+summary.json structure
+-----------------------
+::
+
+    {
+      "page": {
+        "id": "abc123",
+        "name": "My Service",
+        "url": "https://status.myservice.com",
+        "status": "UP"           # UP | HASISSUES | UNDERMAINTENANCE
+      },
+      "activeIncidents": [
+        {
+          "id": "inc_xyz",
+          "name": "API degradation",
+          "started": "2024-01-15T10:00:00.000Z",
+          "status": "INVESTIGATING",   # INVESTIGATING | IDENTIFIED | MONITORING | RESOLVED
+          "impact": "MAJOROUTAGE",     # OPERATIONAL | MINOROUTAGE | MAJOROUTAGE | PARTIALOUTAGE
+          "url": "https://status.myservice.com/incidents/inc_xyz"
+          # NOTE: no body/update-text available in the summary endpoint
+        }
+      ],
+      "activeMaintenances": [
+        {
+          "id": "mnt_abc",
+          "name": "Database migration",
+          "start": "2024-01-20T02:00:00.000Z",
+          "duration": 120,             # minutes; no explicit end time in API
+          "status": "NOTSTARTEDYET",   # NOTSTARTEDYET | INPROGRESS | COMPLETED
+          "url": "https://status.myservice.com/maintenances/mnt_abc"
+        }
+      ]
+    }
+
+v2/components.json structure
+------------------------------
+::
+
+    {
+      "page": { "id": "...", "name": "...", "url": "..." },
+      "components": [
+        {
+          "id": "comp_abc",
+          "name": "API",
+          "description": "REST API endpoints",
+          "status": "OPERATIONAL",     # see mapping below
+          "group": null,               # null or { "id": "...", "name": "..." }
+          "showUptime": true
+        }
+      ]
+    }
+
+Status mapping
+--------------
+Overall page status (page.status → indicator):
+
+    ============= ================
+    Instatus      Normalised
+    ============= ================
+    UP            none
+    HASISSUES     major
+    UNDERMAINTENANCE none  (maintenances tracked separately)
+    ============= ================
+
+Component status (component.status → Component.status):
+
+    ===================== =========================
+    Instatus              Normalised
+    ===================== =========================
+    OPERATIONAL           operational
+    DEGRADEDPERFORMANCE   degraded_performance
+    PARTIALOUTAGE         partial_outage
+    MAJOROUTAGE           major_outage
+    UNDERMAINTENANCE      under_maintenance
+    ===================== =========================
+
+Field differences vs Atlassian Statuspage
+------------------------------------------
+- Incident start time: ``started`` (not ``started_at``)
+- Incident link:       ``url`` (not ``shortlink``)
+- Maintenance start:   ``start`` (not ``scheduled_for``)
+- Maintenance end:     not available — derive from ``start + duration``
+- Incident body:       NOT available in the public summary API
+                       → skip ``active_incident_description`` sensor for this provider
+- Page updated_at:     not available in summary
+
+TODO: implement this provider
+------------------------------
+1. Implement ``detect``:
+   - GET {url}/summary.json, expect 200
+   - Verify ``data.get("page", {}).get("status") in {"UP", "HASISSUES", "UNDERMAINTENANCE"}``
+   - Verify ``"components"`` is NOT a root-level key (distinguishes from Atlassian)
+
+2. Implement ``fetch``:
+   - Use ``asyncio.gather`` to call both endpoints in parallel:
+       a. GET {url}/summary.json
+       b. GET {url}/v2/components.json
+   - Map ``page.status`` to OverallStatus.indicator (see table above)
+   - Map ``activeIncidents`` → list[Incident] (use ``started``, ``url`` fields)
+   - Map ``activeMaintenances`` → list[Maintenance] (derive end from start+duration)
+   - Map ``components`` from components endpoint → list[Component]
+   - ``activeIncidents`` / ``activeMaintenances`` may be absent when empty — use
+     ``.get("activeIncidents") or []``
+
+3. Skip ``active_incident_description`` sensor:
+   - Instatus does not expose incident update bodies in the public API.
+   - Set a class-level flag ``SUPPORTS_INCIDENT_BODY: ClassVar[bool] = False``
+     so sensor.py can skip creating the sensor for this provider.
+
+4. Register provider:
+   - Add ``InstatusProvider`` to ``PROVIDERS`` in ``providers/__init__.py``
+   - Add ``PROVIDER_INSTATUS`` import in ``providers/__init__.py``
+"""
+from __future__ import annotations
+
+from typing import ClassVar
+
+import aiohttp
+
+from .base import StatusPageData
+
+
+class InstatusProvider:
+    """Provider for the Instatus platform (not yet implemented)."""
+
+    ID: ClassVar[str] = "instatus"
+    NAME: ClassVar[str] = "Instatus"
+    SHORT_NAME: ClassVar[str] = "Instatus"
+    SUPPORTS_INCIDENT_BODY: ClassVar[bool] = False
+
+    @classmethod
+    async def detect(
+        cls,
+        session: aiohttp.ClientSession,
+        url: str,
+        timeout: int,
+    ) -> bool:
+        raise NotImplementedError("Instatus provider is not yet implemented")
+
+    @classmethod
+    async def fetch(
+        cls,
+        session: aiohttp.ClientSession,
+        url: str,
+        timeout: int,
+    ) -> StatusPageData:
+        raise NotImplementedError("Instatus provider is not yet implemented")

--- a/custom_components/statuspage_monitor/providers/statuspage_io.py
+++ b/custom_components/statuspage_monitor/providers/statuspage_io.py
@@ -52,6 +52,7 @@ class StatuspageIoProvider:
 
     ID: ClassVar[str] = "statuspage_io"
     NAME: ClassVar[str] = "Atlassian Statuspage (Statuspage.io)"
+    SHORT_NAME: ClassVar[str] = "Atlassian"
 
     @classmethod
     async def detect(

--- a/custom_components/statuspage_monitor/sensor.py
+++ b/custom_components/statuspage_monitor/sensor.py
@@ -2,15 +2,18 @@
 
 Creates the following sensors per configured status page:
 
+  • Provider info            – name of the provider (e.g. "Atlassian")
   • Overall status          – enum: none / minor / major / critical
   • Active incidents        – integer count with incident details as attributes
   • Active incident body    – latest update text of the first active incident
+                              (only for providers that support it)
   • Scheduled maintenances  – integer count with maintenance details
   • Per-component status    – enum: operational / degraded_performance /
                               partial_outage / major_outage / under_maintenance
 
-The icon_color attribute is exposed via extra_state_attributes so that
-Mushroom template cards can read it with:
+Every sensor exposes ``icon`` and ``icon_color`` via extra_state_attributes so
+that Mushroom template cards can read them with:
+  icon:       "{{ state_attr(config.entity, 'icon') }}"
   icon_color: "{{ state_attr(config.entity, 'icon_color') }}"
 """
 from __future__ import annotations
@@ -35,29 +38,73 @@ from .const import (
     COMPONENT_ICONS,
     COMPONENT_OPERATIONAL,
     COMPONENT_STATUS_OPTIONS,
+    CONF_PAGE_NAME,
+    CONF_PROVIDER,
     CONF_URL,
     DOMAIN,
     INDICATOR_COLORS,
     INDICATOR_ICONS,
     INDICATOR_NONE,
     INDICATOR_OPTIONS,
+    PROVIDER_STATUSPAGE_IO,
 )
 from .coordinator import StatusPageMonitorCoordinator
+from .providers import get_provider
 from .providers.base import Component, StatusPageData
 
 _LOGGER = logging.getLogger(__name__)
 
+# Map incident impact values to icon colours.
+_IMPACT_COLORS: dict[str, str] = {
+    "critical": "red",
+    "major": "orange",
+    "minor": "yellow",
+    "none": "yellow",
+}
+_IMPACT_SEVERITY: dict[str, int] = {
+    "critical": 3,
+    "major": 2,
+    "minor": 1,
+    "none": 0,
+}
+
+# MDI icons per provider (for use as icon attribute on ProviderInfoSensor).
+_PROVIDER_ICONS: dict[str, str] = {
+    "statuspage_io": "mdi:atlassian",
+    "instatus": "mdi:information",
+    "cachet": "mdi:information",
+}
+
 
 def _page_slug(coordinator: StatusPageMonitorCoordinator, entry: ConfigEntry) -> str:
-    """Return a URL-safe slug derived from the status page name (or URL fallback)."""
+    """Return a URL-safe slug derived from the status page name.
+
+    Resolution order:
+    1. Live page name from coordinator data (most accurate).
+    2. Page name stored in config entry data (set during config flow — avoids
+       race conditions where coordinator.data is not yet populated on first
+       entity creation).
+    3. URL fallback (last resort).
+    """
     data: StatusPageData | None = coordinator.data
-    name = (data.page.name if data else None) or entry.data[CONF_URL]
+    name = (
+        (data.page.name if data else None)
+        or entry.data.get(CONF_PAGE_NAME)
+        or entry.data[CONF_URL]
+    )
     return slugify(name)
 
 
 # ---------------------------------------------------------------------------
 # Entity descriptions for the static (non-component) sensors
 # ---------------------------------------------------------------------------
+
+PROVIDER_INFO_DESCRIPTION = SensorEntityDescription(
+    key="provider_info",
+    translation_key="provider_info",
+    has_entity_name=True,
+    icon="mdi:information",
+)
 
 OVERALL_STATUS_DESCRIPTION = SensorEntityDescription(
     key="overall_status",
@@ -103,11 +150,18 @@ async def async_setup_entry(
 ) -> None:
     """Set up StatusPage Monitor sensors from a config entry.
 
-    Static sensors (overall status, incidents, maintenances) are created
-    immediately.  Component sensors are added on the first coordinator
+    Static sensors (provider info, overall status, incidents, maintenances) are
+    created immediately.  Component sensors are added on the first coordinator
     update and whenever new components appear in subsequent updates.
+
+    The active_incident_description sensor is omitted for providers that do not
+    expose incident body text (``SUPPORTS_INCIDENT_BODY = False``).
     """
     coordinator: StatusPageMonitorCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    provider_id = entry.data.get(CONF_PROVIDER, PROVIDER_STATUSPAGE_IO)
+    provider_class = get_provider(provider_id)
+    supports_incident_body = getattr(provider_class, "SUPPORTS_INCIDENT_BODY", True)
 
     known_component_ids: set[str] = set()
     static_added = False
@@ -118,14 +172,15 @@ async def async_setup_entry(
         entities: list[SensorEntity] = []
 
         if not static_added and coordinator.data:
-            entities.extend(
-                [
-                    OverallStatusSensor(coordinator, entry),
-                    ActiveIncidentsSensor(coordinator, entry),
-                    ActiveIncidentBodySensor(coordinator, entry),
-                    ScheduledMaintenanceSensor(coordinator, entry),
-                ]
-            )
+            static: list[SensorEntity] = [
+                ProviderInfoSensor(coordinator, entry),
+                OverallStatusSensor(coordinator, entry),
+                ActiveIncidentsSensor(coordinator, entry),
+                ScheduledMaintenanceSensor(coordinator, entry),
+            ]
+            if supports_incident_body:
+                static.insert(3, ActiveIncidentBodySensor(coordinator, entry))
+            entities.extend(static)
             static_added = True
 
         for component in (coordinator.data.components if coordinator.data else []):
@@ -183,6 +238,61 @@ class _StatusPageEntity(
 
 
 # ---------------------------------------------------------------------------
+# Provider info sensor
+# ---------------------------------------------------------------------------
+
+
+class ProviderInfoSensor(_StatusPageEntity):
+    """Sensor reporting the provider platform for this status page.
+
+    State is the short provider name (e.g. "Atlassian", "Instatus", "Cachet").
+    The entity_picture is set to the page's favicon so the provider logo is
+    shown automatically in the frontend.
+    """
+
+    entity_description = PROVIDER_INFO_DESCRIPTION
+
+    def __init__(
+        self,
+        coordinator: StatusPageMonitorCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_provider_info"
+        self._attr_suggested_object_id = (
+            f"statuspage_{_page_slug(coordinator, entry)}_provider_info"
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return the short provider name."""
+        provider_id = self._entry.data.get(CONF_PROVIDER, PROVIDER_STATUSPAGE_IO)
+        provider_class = get_provider(provider_id)
+        return getattr(provider_class, "SHORT_NAME", provider_class.NAME)
+
+    @property
+    def entity_picture(self) -> str:
+        """Return the favicon URL of the status page as the entity picture."""
+        return f"{self._entry.data[CONF_URL]}/favicon.ico"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        provider_id = self._entry.data.get(CONF_PROVIDER, PROVIDER_STATUSPAGE_IO)
+        provider_class = get_provider(provider_id)
+        data: StatusPageData | None = self.coordinator.data
+        attrs: dict[str, Any] = {
+            "provider_id": provider_id,
+            "provider_name": provider_class.NAME,
+            "page_url": self._entry.data[CONF_URL],
+            "favicon_url": f"{self._entry.data[CONF_URL]}/favicon.ico",
+            "icon": _PROVIDER_ICONS.get(provider_id, "mdi:information"),
+        }
+        if data and data.page.updated_at:
+            attrs["page_updated_at"] = data.page.updated_at
+        return attrs
+
+
+# ---------------------------------------------------------------------------
 # Overall status sensor
 # ---------------------------------------------------------------------------
 
@@ -229,6 +339,7 @@ class OverallStatusSensor(_StatusPageEntity):
             "page_name": data.page.name,
             "page_url": self._entry.data[CONF_URL],
             "page_updated_at": data.page.updated_at,
+            "icon": self.icon,
             "icon_color": INDICATOR_COLORS.get(self.native_value, "grey"),
         }
 
@@ -268,8 +379,18 @@ class ActiveIncidentsSensor(_StatusPageEntity):
         return data.incidents if data else []
 
     @property
+    def _icon_color(self) -> str:
+        incidents = self._active_incidents
+        if not incidents:
+            return "green"
+        worst = max(incidents, key=lambda i: _IMPACT_SEVERITY.get(i.impact, 0))
+        return _IMPACT_COLORS.get(worst.impact, "yellow")
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         return {
+            "icon": self.icon,
+            "icon_color": self._icon_color,
             "incidents": [
                 {
                     "id": inc.id,
@@ -281,7 +402,7 @@ class ActiveIncidentsSensor(_StatusPageEntity):
                     "updated_at": inc.updated_at,
                 }
                 for inc in self._active_incidents
-            ]
+            ],
         }
 
 
@@ -296,6 +417,9 @@ class ActiveIncidentBodySensor(_StatusPageEntity):
     The state is the body text of the most recent incident update, ready to
     use directly in a Markdown card or as a notification message.  When there
     are no active incidents the state is None (shown as 'unknown' in HA).
+
+    This sensor is only created for providers that expose incident body text
+    (``SUPPORTS_INCIDENT_BODY = True``, which is the default).
     """
 
     entity_description = INCIDENT_BODY_DESCRIPTION
@@ -329,13 +453,19 @@ class ActiveIncidentBodySensor(_StatusPageEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         inc = self._first_incident
+        color = _IMPACT_COLORS.get(inc.impact, "yellow") if inc else "green"
         if not inc:
-            return {}
+            return {
+                "icon": self.icon,
+                "icon_color": color,
+            }
         return {
             "incident_id": inc.id,
             "incident_name": inc.name,
             "incident_status": inc.status,
             "incident_impact": inc.impact,
+            "icon": self.icon,
+            "icon_color": color,
         }
 
 
@@ -374,6 +504,8 @@ class ScheduledMaintenanceSensor(_StatusPageEntity):
         data: StatusPageData | None = self.coordinator.data
         maintenances = data.scheduled_maintenances if data else []
         return {
+            "icon": self.icon,
+            "icon_color": "blue" if self.native_value > 0 else "green",
             "maintenances": [
                 {
                     "id": m.id,
@@ -385,7 +517,7 @@ class ScheduledMaintenanceSensor(_StatusPageEntity):
                     "scheduled_until": m.scheduled_until,
                 }
                 for m in maintenances
-            ]
+            ],
         }
 
 
@@ -458,7 +590,11 @@ class ComponentSensor(_StatusPageEntity):
         comp = self._component_data
         color = COMPONENT_COLORS.get(self.native_value, "grey")
         if not comp:
-            return {"component_id": self._component_id, "icon_color": color}
+            return {
+                "component_id": self._component_id,
+                "icon": self.icon,
+                "icon_color": color,
+            }
         return {
             "component_id": self._component_id,
             "description": comp.description,
@@ -466,6 +602,7 @@ class ComponentSensor(_StatusPageEntity):
             "group_id": comp.group_id,
             "updated_at": comp.updated_at,
             "showcase": comp.showcase,
+            "icon": self.icon,
             "icon_color": color,
         }
 

--- a/custom_components/statuspage_monitor/strings.json
+++ b/custom_components/statuspage_monitor/strings.json
@@ -40,6 +40,9 @@
   },
   "entity": {
     "sensor": {
+      "provider_info": {
+        "name": "Provider"
+      },
       "overall_status": {
         "name": "Overall Status",
         "state": {

--- a/custom_components/statuspage_monitor/translations/en.json
+++ b/custom_components/statuspage_monitor/translations/en.json
@@ -40,6 +40,9 @@
   },
   "entity": {
     "sensor": {
+      "provider_info": {
+        "name": "Provider"
+      },
       "overall_status": {
         "name": "Overall Status",
         "state": {

--- a/custom_components/statuspage_monitor/translations/nl.json
+++ b/custom_components/statuspage_monitor/translations/nl.json
@@ -40,6 +40,9 @@
   },
   "entity": {
     "sensor": {
+      "provider_info": {
+        "name": "Provider"
+      },
       "overall_status": {
         "state": {
           "none": "Operationeel",
@@ -47,6 +50,15 @@
           "major": "Grote problemen",
           "critical": "Kritiek"
         }
+      },
+      "active_incidents": {
+        "name": "Actieve incidenten"
+      },
+      "active_incident_description": {
+        "name": "Actief incident – beschrijving"
+      },
+      "scheduled_maintenances": {
+        "name": "Geplande onderhoudswerkzaamheden"
       },
       "component_status": {
         "state": {


### PR DESCRIPTION
- sensor.py: new ProviderInfoSensor (state=short name, entity_picture=favicon)
- sensor.py: add icon + icon_color to extra_state_attributes on all sensors
- sensor.py: ActiveIncidentsSensor icon_color reflects worst incident impact
- sensor.py: ScheduledMaintenanceSensor icon_color green/blue
- sensor.py: ActiveIncidentBodySensor gets icon_color based on incident impact
- sensor.py: skip active_incident_description for providers with SUPPORTS_INCIDENT_BODY=False
- sensor.py/_page_slug: use stored CONF_PAGE_NAME as fallback to fix entity-ID bug where IDs lacked the statuspage_ prefix on first setup
- config_flow.py: store page_name in config entry data (feeds _page_slug fix)
- const.py: add CONF_PAGE_NAME, PROVIDER_INSTATUS, PROVIDER_CACHET
- providers/statuspage_io.py: add SHORT_NAME = "Atlassian"
- providers/instatus.py: replace empty stub with full implementation guide
- providers/cachet.py: replace empty stub with full implementation guide
- strings.json + en.json + nl.json: add provider_info sensor translation
- nl.json: add missing active_incidents, active_incident_description, scheduled_maintenances translations

https://claude.ai/code/session_01K7CJViPAXXK5sicCYoP68X