### PR TITLE
feat: multi-provider support (Status.io, UptimeRobot, Cachet) + provider logos

### DIFF
--- a/custom_components/statuspage_monitor/__init__.py
+++ b/custom_components/statuspage_monitor/__init__.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -41,7 +42,9 @@ _LOGOS_DIR = Path(__file__).parent / "providers" / "logos"
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Register static logo assets so entity_picture URLs resolve inside HA."""
-    hass.http.register_static_path(_LOGOS_URL_PATH, str(_LOGOS_DIR), cache_headers=True)
+    await hass.http.async_register_static_paths(
+        [StaticPathConfig(_LOGOS_URL_PATH, str(_LOGOS_DIR), cache_headers=True)]
+    )
     return True
 
 

--- a/custom_components/statuspage_monitor/manifest.json
+++ b/custom_components/statuspage_monitor/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "statuspage_monitor",
   "name": "StatusPage Monitor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://github.com/TheLion/statuspage-HA",


### PR DESCRIPTION
### New providers (v1.1.0)
- **Status.io** – detection via HTML `statuspageId` + public API
- **UptimeRobot** – detection via `window.pspApiPath` embedded in page HTML
- **Cachet** – supports both v2 and v3, detection via ping endpoint

### Provider abstraction
- All providers live in `providers/` as standalone Python files
- Adding a new provider = one file + register it in `PROVIDERS`
- Auto-detection: tries providers in order until one matches the URL

### New sensor: Provider
- Shows which provider was detected (e.g. "UptimeRobot")
- Displays the provider logo as `entity_picture`

### Other improvements
- All sensors expose `icon` and `icon_color` as attributes (for Mushroom Cards)
- Entity-ID fix: `page_name` is stored at setup time as a stable fallback
- Bugfix: `register_static_path` → `async_register_static_paths` (newer HA versions)
