### PR TITLE
Fix providers import: use package public API instead of internal subm…

### DIFF
--- a/custom_components/statuspage_monitor/coordinator.py
+++ b/custom_components/statuspage_monitor/coordinator.py
@@ -20,7 +20,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
-from .providers.base import StatusPageData
+from .providers import StatusPageData
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/statuspage_monitor/providers/__init__.py
+++ b/custom_components/statuspage_monitor/providers/__init__.py
@@ -12,7 +12,7 @@ import logging
 
 import aiohttp
 
-from .base import StatusPageData, StatusPageProvider  # noqa: F401 – re-exported
+from .base import Component, StatusPageData, StatusPageProvider  # noqa: F401 – re-exported
 from .cachet import CachetProvider
 from .status_io import StatusIoProvider
 from .statuspage_io import StatuspageIoProvider

--- a/custom_components/statuspage_monitor/sensor.py
+++ b/custom_components/statuspage_monitor/sensor.py
@@ -51,8 +51,7 @@ from .const import (
     PROVIDER_STATUSPAGE_IO,
 )
 from .coordinator import StatusPageMonitorCoordinator
-from .providers import get_provider
-from .providers.base import Component, StatusPageData
+from .providers import Component, StatusPageData, get_provider
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
…odule

coordinator.py and sensor.py were importing directly from providers.base (the internal submodule), which fails when the providers package cannot be resolved as a namespace. Changed both files to import through the providers package public interface (__init__.py re-exports), and added Component to the re-exported names.

https://claude.ai/code/session_01MdQtZ6xDXCQYvunH86edLj