### PR TITLE
ci: bump GitHub Actions to v6 for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- Runners force Node 24 from **2026-06-02**; current `v4`/`v5` actions run on deprecated Node 20.

| Action | Old | New |
|---|---|---|
| `actions/checkout`      | v4 | **v6** |
| `actions/setup-python`  | v5 | **v6** |

## Test plan
- [ ] CI on this PR runs green (pytest on Python 3.11/3.12/3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)